### PR TITLE
fix: log date time as local time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@oclif/plugin-not-found": "^3.2.1",
         "@rpidanny/google-scholar": "^1.0.1",
         "@rpidanny/odysseus": "^1.2.0",
-        "@rpidanny/quill": "^1.5.0",
+        "@rpidanny/quill": "^1.5.1",
         "bottleneck": "^2.19.5",
         "cheerio": "^1.0.0-rc.12",
         "csvtojson": "^2.0.10",
@@ -3745,9 +3745,12 @@
       }
     },
     "node_modules/@rpidanny/quill": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@rpidanny/quill/-/quill-1.5.0.tgz",
-      "integrity": "sha512-FPFTzG7UhtBXROdDhiOSq4fAdLOvlJhOrnNFR3b4Vrcnl3ZvNP6VumdQiFebwxrr7TAlXpByLiZFi+4L7vxbyg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rpidanny/quill/-/quill-1.5.1.tgz",
+      "integrity": "sha512-S1hWy2efy9rMtxfoO8hqJd/0VL4gM+tq8GAFqCF9DZ4aC/uQYXVUktnKlpgak26/ftGPWxqAT+dL2cGmKWiojw==",
+      "dependencies": {
+        "moment": "2.30.1"
+      }
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -12097,6 +12100,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@oclif/plugin-not-found": "^3.2.1",
     "@rpidanny/google-scholar": "^1.0.1",
     "@rpidanny/odysseus": "^1.2.0",
-    "@rpidanny/quill": "^1.5.0",
+    "@rpidanny/quill": "^1.5.1",
     "bottleneck": "^2.19.5",
     "cheerio": "^1.0.0-rc.12",
     "csvtojson": "^2.0.10",


### PR DESCRIPTION
Fix log date time as local time instead of ISO string

example:

```sh
  ____                      _
 |  _ \  __ _ _ ____      _(_)_ __
 | | | |/ _` | '__\ \ /\ / / | '_ \
 | |_| | (_| | |   \ V  V /| | | | |
 |____/ \__,_|_|    \_/\_/ |_|_| |_|
                                     beta v1.2.0
[2024-06-09 02:36:00.91 +02:00] [INFO] Searching papers related to: crispr cas9
[2024-06-09 02:36:00.91 +02:00] [DEBUG] Searching by URL: https://scholar.google.com/scholar?hl=en&q=crispr%20cas9
[2024-06-09 02:36:02.60 +02:00] [DEBUG] Fetching content from https://scholar.google.com/scholar?hl=en&q=crispr%20cas9
[2024-06-09 02:36:06.97 +02:00] [WARN] Captcha detected. Waiting for user input...
[2024-06-09 02:37:07.08 +02:00] [DEBUG] Searching by URL: https://scholar.google.com/scholar?start=10&q=crispr+cas9&hl=en&as_sdt=0,5
[2024-06-09 02:37:07.09 +02:00] [DEBUG] Fetching content from https://scholar.google.com/scholar?start=10&q=crispr+cas9&hl=en&as_sdt=0,5
[2024-06-09 02:37:10.80 +02:00] [DEBUG] Searching by URL: https://scholar.google.com/scholar?start=20&q=crispr+cas9&hl=en&as_sdt=0,5
[2024-06-09 02:37:10.81 +02:00] [DEBUG] Fetching content from https://scholar.google.com/scholar?start=20&q=crispr+cas9&hl=en&as_sdt=0,5
[2024-06-09 02:37:14.18 +02:00] [DEBUG] Searching by URL: https://scholar.google.com/scholar?start=30&q=crispr+cas9&hl=en&as_sdt=0,5
[2024-06-09 02:37:14.19 +02:00] [DEBUG] Fetching content from https://scholar.google.com/scholar?start=30&q=crispr+cas9&hl=en&as_sdt=0,5
[2024-06-09 02:37:17.64 +02:00] [INFO] Writing to crispr_cas9_1.csv
```