### PR TITLE
feat: add update command

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,10 +17,10 @@
 Updating Darwin is straightforward. Execute the following command:
 
 ```bash
-npm i -g @rpidanny/darwin@latest
+darwin update
 ```
 
-This command will globally install the latest version of Darwin from the npm registry, ensuring you have the most up-to-date features and improvements available.
+This command will install the latest version of Darwin, ensuring you have the most up-to-date features and improvements available.
 
 ## How do I configure Darwin to work with a local LLM?
 

--- a/src/commands/update/index.ts
+++ b/src/commands/update/index.ts
@@ -1,0 +1,24 @@
+import { spawn } from 'child_process'
+
+import { BaseCommand } from '../../base.command.js'
+
+export default class Update extends BaseCommand<typeof Update> {
+  static override description = 'Update Darwin to the latest version.'
+
+  static override examples = ['<%= config.bin %> <%= command.id %>']
+
+  public async run(): Promise<void> {
+    this.logger.info('Updating Darwin...')
+
+    const shell = spawn('npm install -g @rpidanny/darwin@latest', {
+      stdio: 'inherit',
+      shell: true,
+    })
+
+    shell.on('close', (code: number | null) => {
+      if (code !== null && code !== 0) {
+        this.exit(code)
+      }
+    })
+  }
+}

--- a/src/hooks/init/check-update.ts
+++ b/src/hooks/init/check-update.ts
@@ -5,7 +5,7 @@ import semver from 'semver'
 import ui from '../../utils/ui/output.js'
 
 const hook: Hook<'init'> = async function (opts) {
-  if (opts.id && ['autocomplete:script', 'readme'].includes(opts.id)) return
+  if (opts.id && ['autocomplete:script', 'readme', 'update'].includes(opts.id)) return
 
   try {
     const { version: latestVersion } = await got(

--- a/src/utils/ui/output.ts
+++ b/src/utils/ui/output.ts
@@ -15,7 +15,7 @@ function printUpdateBanner(version: string, log: (msg: string) => void): void {
   log(
     `${chalk.hex('#cf402f')(
       `A new version (v${version}) of darwin is available. Please run ${chalk.bold(
-        'npm install -g @rpidanny/darwin@latest',
+        'darwin update',
       )} to update and enjoy the latest features!`,
     )}`,
   )


### PR DESCRIPTION
Add an `update` command that internally runs `npm i -g @rpidanny/darwin@latest` so that users doesn't need to know/remember the npm command.