### PR TITLE
feat: add --year-high and --year-low flag

### DIFF
--- a/src/commands/search/accession.ts
+++ b/src/commands/search/accession.ts
@@ -16,6 +16,8 @@ import questionFlag from '../../inputs/flags/question.flag.js'
 import skipCaptchaFlag from '../../inputs/flags/skip-captcha.flag.js'
 import summaryFlag from '../../inputs/flags/summary.flag.js'
 import summaryMethodFlag from '../../inputs/flags/summary-method.flag.js'
+import yearHighFlag from '../../inputs/flags/year-high.flag.js'
+import yearLowFlag from '../../inputs/flags/year-low.flag.js'
 import { PaperSearchService } from '../../services/search/paper-search.service.js'
 
 export default class SearchAccession extends BaseCommand<typeof SearchAccession> {
@@ -51,6 +53,8 @@ export default class SearchAccession extends BaseCommand<typeof SearchAccession>
     'summary-method': summaryMethodFlag,
     llm: llmProviderFlag,
     question: questionFlag,
+    'year-low': yearLowFlag,
+    'year-high': yearHighFlag,
   }
 
   async init(): Promise<void> {
@@ -97,6 +101,8 @@ export default class SearchAccession extends BaseCommand<typeof SearchAccession>
       summary,
       question,
       'summary-method': summaryMethod,
+      'year-low': yearLow,
+      'year-high': yearHigh,
     } = this.flags
     const { keywords } = this.args
 
@@ -104,6 +110,8 @@ export default class SearchAccession extends BaseCommand<typeof SearchAccession>
 
     const outputPath = await this.searchService.exportToCSV(output, {
       keywords,
+      yearLow,
+      yearHigh,
       minItemCount: count,
       filterPattern,
       summarize: summary,

--- a/src/commands/search/papers.ts
+++ b/src/commands/search/papers.ts
@@ -15,6 +15,8 @@ import questionFlag from '../../inputs/flags/question.flag.js'
 import skipCaptchaFlag from '../../inputs/flags/skip-captcha.flag.js'
 import summaryFlag from '../../inputs/flags/summary.flag.js'
 import summaryMethodFlag from '../../inputs/flags/summary-method.flag.js'
+import yearHighFlag from '../../inputs/flags/year-high.flag.js'
+import yearLowFlag from '../../inputs/flags/year-low.flag.js'
 import { PaperSearchService } from '../../services/search/paper-search.service.js'
 
 export default class SearchPapers extends BaseCommand<typeof SearchPapers> {
@@ -45,6 +47,8 @@ export default class SearchPapers extends BaseCommand<typeof SearchPapers> {
     'summary-method': summaryMethodFlag,
     llm: llmProviderFlag,
     question: questionFlag,
+    'year-low': yearLowFlag,
+    'year-high': yearHighFlag,
   }
 
   async init(): Promise<void> {
@@ -86,13 +90,24 @@ export default class SearchPapers extends BaseCommand<typeof SearchPapers> {
   }
 
   public async run(): Promise<void> {
-    const { count, output, filter, summary, question, 'summary-method': summaryMethod } = this.flags
+    const {
+      count,
+      output,
+      filter,
+      summary,
+      question,
+      'summary-method': summaryMethod,
+      'year-low': yearLow,
+      'year-high': yearHigh,
+    } = this.flags
     const { keywords } = this.args
 
     this.logger.info(`Searching papers for: ${keywords}`)
 
     const outputFile = await this.searchService.exportToCSV(output, {
       keywords,
+      yearLow,
+      yearHigh,
       minItemCount: count,
       filterPattern: filter,
       summarize: summary,

--- a/src/inputs/flags/year-high.flag.ts
+++ b/src/inputs/flags/year-high.flag.ts
@@ -1,0 +1,7 @@
+import { Flags } from '@oclif/core'
+
+export default Flags.integer({
+  helpValue: 'YEAR',
+  summary: 'Highest year to include in the search.',
+  required: false,
+})

--- a/src/inputs/flags/year-low.flag.ts
+++ b/src/inputs/flags/year-low.flag.ts
@@ -1,0 +1,7 @@
+import { Flags } from '@oclif/core'
+
+export default Flags.integer({
+  helpValue: 'YEAR',
+  summary: 'Lowest year to include in the search.',
+  required: false,
+})

--- a/src/services/search/interfaces.ts
+++ b/src/services/search/interfaces.ts
@@ -23,4 +23,6 @@ export interface ISearchOptions {
   summaryMethod?: SummaryMethod
   question?: string
   onData?: (data: IPaperEntity) => Promise<any>
+  yearLow?: number
+  yearHigh?: number
 }

--- a/src/services/search/paper-search.service.spec.ts
+++ b/src/services/search/paper-search.service.spec.ts
@@ -184,6 +184,25 @@ describe('PaperSearchService', () => {
         })),
       )
     })
+
+    it('should pass yearLow and yearHigh to GoogleScholar', async () => {
+      await service.search({
+        keywords: 'some keywords',
+        minItemCount: 10,
+        yearLow: 2_010,
+        yearHigh: 2_020,
+      })
+
+      expect(googleScholarMock.iteratePapers).toHaveBeenCalledWith(
+        {
+          keywords: 'some keywords',
+          yearLow: 2_010,
+          yearHigh: 2_020,
+        },
+        expect.any(Function),
+        mockConfig.concurrency,
+      )
+    })
   })
 
   describe('exportToCSV', () => {

--- a/src/services/search/paper-search.service.ts
+++ b/src/services/search/paper-search.service.ts
@@ -23,6 +23,8 @@ export class PaperSearchService {
 
   public async search({
     keywords,
+    yearLow,
+    yearHigh,
     minItemCount,
     filterPattern,
     summarize,
@@ -33,7 +35,7 @@ export class PaperSearchService {
     const papers: IPaperEntity[] = []
 
     await this.googleScholar.iteratePapers(
-      { keywords },
+      { keywords, yearLow, yearHigh },
       async paper => {
         const entity = await this.processPaper(paper, {
           filterPattern,


### PR DESCRIPTION
Add `year-high` and `year-low` flags in search commands to filter search results by publication year